### PR TITLE
PCL 1.14 stops adding the version number to the pkg-config files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,7 @@
 find_package(PCL 1.7 REQUIRED COMPONENTS segmentation)
+IF("${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}" VERSION_LESS 1.14)
+    SET(PCL_VERSION_SUFFIX "-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
+ENDIF()
 
 rock_library(traversability_generator3d
     SOURCES TraversabilityGenerator3d.cpp
@@ -9,6 +12,6 @@ rock_library(traversability_generator3d
     DEPS_PKGCONFIG 
         base-types 
         maps
-        pcl_segmentation-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}
+        pcl_segmentation${PCL_VERSION_SUFFIX}
         vizkit3d_debug_drawings-commands
 )


### PR DESCRIPTION
@haider8645 can you check if this doesn't break Ubuntu 20.04/22.04?