### PR TITLE
Use old QT connect syntax for compatibility with QT4

### DIFF
--- a/gui/TraversabilityGenerator3dGui.cpp
+++ b/gui/TraversabilityGenerator3dGui.cpp
@@ -110,7 +110,7 @@ void TraversabilityGenerator3dGui::setupUI()
             this, SLOT(picked(float,float,float,int,int)));
     connect(&trav3dViz, SIGNAL(picked(float,float,float,int,int)), 
             this, SLOT(picked(float,float,float,int,int)));
-    connect(resetButton, &QPushButton::clicked, this, &TraversabilityGenerator3dGui::resetTravMap);
+    connect(resetButton, SIGNAL(clicked(bool)), this, SLOT(resetTravMap()));
 }
 
 void TraversabilityGenerator3dGui::loadTravConfigFromYaml(const std::string& file)


### PR DESCRIPTION
The other syntax does not work with QT4 on Ubuntu 20.04.
Alternatively, we could just disable QT4 support.