### PR TITLE
Fix compilation with ENABLE_DEBUG_DRAWINGS=ON

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -13,7 +13,7 @@ IF("${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}" VERSION_LESS 1.14)
     SET(PCL_VERSION_SUFFIX "-${PCL_VERSION_MAJOR}.${PCL_VERSION_MINOR}")
 ENDIF()
 
-if(ENABLE_DEBUG_DRAWINGS AND vizkit3d_debug_drawings-commands_FOUND)
+if(ENABLE_DEBUG_DRAWINGS)
 	# These are (only) required for building the GUIs:
 	list(APPEND DEPS_PKGCONFIG_QT vizkit3d_debug_drawings)
 endif()


### PR DESCRIPTION
Otherwise, you get a linking error:

```
    /usr/bin/ld: libtraversability_generator3d_gui-qt5.so: undefined reference to `V3DD::CONFIGURE_DEBUG_DRAWINGS_USE_EXISTING_WIDGET(vizkit3d::Vizkit3DWidget*)'
    collect2: error: ld returned 1 exit status
```