### PR TITLE
Update inflation

### DIFF
--- a/gui/TraversabilityGenerator3dGui.cpp
+++ b/gui/TraversabilityGenerator3dGui.cpp
@@ -16,6 +16,10 @@
 #include <fstream>
 #include <traversability_generator3d/SoilNode.hpp>
 #include <yaml-cpp/yaml.h>
+#include <osg/MatrixTransform>
+#include <osg/Geode>
+#include <osg/ShapeDrawable>
+#include <osg/PolygonMode>
 
 #ifdef ENABLE_DEBUG_DRAWINGS
 #include <vizkit3d_debug_drawings/DebugDrawing.hpp>
@@ -97,6 +101,18 @@ void TraversabilityGenerator3dGui::setupUI()
     layout->addLayout(soilLayout);
     layout->addWidget(soilHintLabel);
 
+    QHBoxLayout* yawLayout = new QHBoxLayout();
+    yawSpin_ = new QDoubleSpinBox();
+    yawSpin_->setRange(-180.0, 180.0);
+    yawSpin_->setValue(0.0);
+    yawSpin_->setSingleStep(5.0);
+    yawSpin_->setSuffix("\xc2\xb0");  // degree sign
+    yawSpin_->setToolTip("Rotate the robot bounding box preview around its vertical axis");
+    yawLayout->addWidget(new QLabel("Robot yaw:"));
+    yawLayout->addWidget(yawSpin_);
+    yawLayout->addStretch();
+    layout->addLayout(yawLayout);
+
     resetButton = new QPushButton("Reset Traversability and Soil Maps");
     resetButton->setEnabled(false);
     layout->addWidget(resetButton);
@@ -111,6 +127,7 @@ void TraversabilityGenerator3dGui::setupUI()
     connect(&trav3dViz, SIGNAL(picked(float,float,float,int,int)), 
             this, SLOT(picked(float,float,float,int,int)));
     connect(resetButton, SIGNAL(clicked(bool)), this, SLOT(resetTravMap()));
+    connect(yawSpin_, SIGNAL(valueChanged(double)), this, SLOT(onYawChanged(double)));
 }
 
 void TraversabilityGenerator3dGui::loadTravConfigFromYaml(const std::string& file)
@@ -192,6 +209,7 @@ void TraversabilityGenerator3dGui::setupTravGen(int argc, char** argv)
 {
     std::string yaml_file = std::string(TRAV3D_CONFIG_DIR) + "/parameters.yaml";
     loadTravConfigFromYaml(yaml_file);
+    setupRobotBoxViz();
     travGen.reset(new traversability_generator3d::TraversabilityGenerator3d(travConfig));
 
     if(argc > 1)
@@ -314,6 +332,7 @@ void TraversabilityGenerator3dGui::picked(float x, float y, float z,
         start.position.z()));
 
     startPicked = true;
+    updateRobotBoxTransform();
     expandAll();
 }
 
@@ -369,6 +388,9 @@ void TraversabilityGenerator3dGui::resetTravMap()
     start.orientation.setIdentity();
     startViz.setTranslation(QVector3D(0,0,0));
 
+    if (robotBoxTransform_)
+        robotBoxTransform_->setNodeMask(0);
+
 #ifdef ENABLE_DEBUG_DRAWINGS
     V3DD::CLEAR_DRAWING("ugv_nav4d_start_aabb");
 #endif
@@ -376,3 +398,59 @@ void TraversabilityGenerator3dGui::resetTravMap()
     LOG_INFO_S << "Traversability map reset complete.";
 }
 
+void TraversabilityGenerator3dGui::setupRobotBoxViz()
+{
+    // Wireframe box matching the robot footprint; hidden until the user clicks.
+    osg::ref_ptr<osg::Box> osgBox = new osg::Box(
+        osg::Vec3(0.0f, 0.0f, static_cast<float>(travConfig.robotHeight / 2.0)),
+        static_cast<float>(travConfig.robotSizeX),
+        static_cast<float>(travConfig.robotSizeY),
+        static_cast<float>(travConfig.robotHeight));
+
+    osg::ref_ptr<osg::ShapeDrawable> sd = new osg::ShapeDrawable(osgBox);
+    sd->setColor(osg::Vec4(0.0f, 1.0f, 1.0f, 1.0f));  // cyan wireframe
+
+    osg::ref_ptr<osg::Geode> geode = new osg::Geode;
+    geode->addDrawable(sd);
+
+    osg::ref_ptr<osg::StateSet> ss = geode->getOrCreateStateSet();
+    osg::ref_ptr<osg::PolygonMode> pm = new osg::PolygonMode;
+    pm->setMode(osg::PolygonMode::FRONT_AND_BACK, osg::PolygonMode::LINE);
+    ss->setAttribute(pm, osg::StateAttribute::ON);
+    ss->setMode(GL_LIGHTING, osg::StateAttribute::OFF);
+
+    robotBoxTransform_ = new osg::MatrixTransform;
+    robotBoxTransform_->addChild(geode);
+    robotBoxTransform_->setNodeMask(0);  // hidden until first click
+    widget->getRootNode()->addChild(robotBoxTransform_);
+}
+
+void TraversabilityGenerator3dGui::updateRobotBoxTransform()
+{
+    if (!robotBoxTransform_ || !startPicked)
+        return;
+
+    const double yawRad = yawSpin_->value() * M_PI / 180.0;
+
+    // Update the startViz arrow to reflect the chosen heading
+    const Eigen::Quaterniond q(Eigen::AngleAxisd(yawRad, Eigen::Vector3d::UnitZ()));
+    start.orientation = q;
+    startViz.setRotation(QQuaternion(
+        static_cast<float>(q.w()),
+        static_cast<float>(q.x()),
+        static_cast<float>(q.y()),
+        static_cast<float>(q.z())));
+
+    // Rotate around Z then translate to the picked position
+    const osg::Matrix mat =
+        osg::Matrix::rotate(yawRad, osg::Vec3d(0.0, 0.0, 1.0)) *
+        osg::Matrix::translate(start.position.x(), start.position.y(), start.position.z());
+
+    robotBoxTransform_->setMatrix(mat);
+    robotBoxTransform_->setNodeMask(~0u);
+}
+
+void TraversabilityGenerator3dGui::onYawChanged(double /*deg*/)
+{
+    updateRobotBoxTransform();
+}

--- a/gui/TraversabilityGenerator3dGui.cpp
+++ b/gui/TraversabilityGenerator3dGui.cpp
@@ -163,8 +163,6 @@ void TraversabilityGenerator3dGui::loadTravConfigFromYaml(const std::string& fil
     travConfig.traverseConcrete         = cfg["traverseConcrete"].as<bool>();
     
     travConfig.obstacleInflationMultiplier = cfg["obstacleInflationMultiplier"] ? cfg["obstacleInflationMultiplier"].as<double>() : travConfig.obstacleInflationMultiplier;
-    travConfig.robotCenterOffsetX = cfg["robotCenterOffsetX"] ? cfg["robotCenterOffsetX"].as<double>() : 0.0;
-    travConfig.robotCenterOffsetY = cfg["robotCenterOffsetY"] ? cfg["robotCenterOffsetY"].as<double>() : 0.0;
 
     // enum
     std::string s = cfg["slopeMetric"].as<std::string>();
@@ -403,12 +401,8 @@ void TraversabilityGenerator3dGui::resetTravMap()
 void TraversabilityGenerator3dGui::setupRobotBoxViz()
 {
     // Wireframe box matching the robot footprint; hidden until the user clicks.
-    // The box centre is offset from the body-frame origin (clicked point) so that
-    // the visualisation matches the collision geometry used in checkStepHeightAABB/OBB.
     osg::ref_ptr<osg::Box> osgBox = new osg::Box(
-        osg::Vec3(static_cast<float>(travConfig.robotCenterOffsetX),
-                  static_cast<float>(travConfig.robotCenterOffsetY),
-                  static_cast<float>(travConfig.robotHeight / 2.0)),
+        osg::Vec3(0.0f, 0.0f, static_cast<float>(travConfig.robotHeight / 2.0)),
         static_cast<float>(travConfig.robotSizeX),
         static_cast<float>(travConfig.robotSizeY),
         static_cast<float>(travConfig.robotHeight));

--- a/gui/TraversabilityGenerator3dGui.cpp
+++ b/gui/TraversabilityGenerator3dGui.cpp
@@ -403,14 +403,18 @@ void TraversabilityGenerator3dGui::resetTravMap()
 void TraversabilityGenerator3dGui::setupRobotBoxViz()
 {
     // Wireframe box matching the robot footprint; hidden until the user clicks.
+    // The box centre is offset from the body-frame origin (clicked point) so that
+    // the visualisation matches the collision geometry used in checkStepHeightAABB/OBB.
     osg::ref_ptr<osg::Box> osgBox = new osg::Box(
-        osg::Vec3(0.0f, 0.0f, static_cast<float>(travConfig.robotHeight / 2.0)),
+        osg::Vec3(static_cast<float>(travConfig.robotCenterOffsetX),
+                  static_cast<float>(travConfig.robotCenterOffsetY),
+                  static_cast<float>(travConfig.robotHeight / 2.0)),
         static_cast<float>(travConfig.robotSizeX),
         static_cast<float>(travConfig.robotSizeY),
         static_cast<float>(travConfig.robotHeight));
 
     osg::ref_ptr<osg::ShapeDrawable> sd = new osg::ShapeDrawable(osgBox);
-    sd->setColor(osg::Vec4(0.0f, 1.0f, 1.0f, 1.0f));  // cyan wireframe
+    sd->setColor(osg::Vec4(1.0f, 0.0f, 0.0f, 1.0f));  // red wireframe
 
     osg::ref_ptr<osg::Geode> geode = new osg::Geode;
     geode->addDrawable(sd);

--- a/gui/TraversabilityGenerator3dGui.cpp
+++ b/gui/TraversabilityGenerator3dGui.cpp
@@ -163,6 +163,8 @@ void TraversabilityGenerator3dGui::loadTravConfigFromYaml(const std::string& fil
     travConfig.traverseConcrete         = cfg["traverseConcrete"].as<bool>();
     
     travConfig.obstacleInflationMultiplier = cfg["obstacleInflationMultiplier"] ? cfg["obstacleInflationMultiplier"].as<double>() : travConfig.obstacleInflationMultiplier;
+    travConfig.robotCenterOffsetX = cfg["robotCenterOffsetX"] ? cfg["robotCenterOffsetX"].as<double>() : 0.0;
+    travConfig.robotCenterOffsetY = cfg["robotCenterOffsetY"] ? cfg["robotCenterOffsetY"].as<double>() : 0.0;
 
     // enum
     std::string s = cfg["slopeMetric"].as<std::string>();

--- a/gui/TraversabilityGenerator3dGui.hpp
+++ b/gui/TraversabilityGenerator3dGui.hpp
@@ -17,6 +17,7 @@
 #include <traversability_generator3d/TraversabilityConfig.hpp>
 #include <traversability_generator3d/TraversabilityGenerator3d.hpp>
 #include <traversability_generator3d/SoilNode.hpp>
+#include <osg/MatrixTransform>
 #endif
 
 class QPushButton;
@@ -44,10 +45,13 @@ public slots:
     void picked(float x, float y,float z, int buttonMask, int modifierMask);
     void expandAll();
     void resetTravMap();
+    void onYawChanged(double deg);
 
 private:
     void loadMls(const std::string& path);
     void loadTravConfigFromYaml(const std::string& path);
+    void setupRobotBoxViz();
+    void updateRobotBoxTransform();
     std::vector<traversability_generator3d::SoilSample> soilSamplesList;
     void applySoilInformationToGenerator();
 
@@ -74,5 +78,8 @@ private:
     QDoubleSpinBox* sigmaYSpin = nullptr;
     QDoubleSpinBox* uncertaintySpin = nullptr;
     QLabel* soilHintLabel = nullptr;
+
+    QDoubleSpinBox* yawSpin_ = nullptr;
+    osg::ref_ptr<osg::MatrixTransform> robotBoxTransform_;
 
 };

--- a/gui/config/parameters.yaml
+++ b/gui/config/parameters.yaml
@@ -12,6 +12,10 @@ travConfig:
   robotSizeY: 0.6
   distToGround: 0.0
 
+  # offset of the robot footprint centre from the body-frame origin [m]
+  # use when the planning reference point is not at the geometric centre of the bounding box
+  robotCenterOffsetX: 0.0
+  robotCenterOffsetY: 0.0
   # slope / terrain constraints
   maxSlope: 0.45                # [rad]
   maxStepHeight: 0.25

--- a/gui/config/parameters.yaml
+++ b/gui/config/parameters.yaml
@@ -12,10 +12,6 @@ travConfig:
   robotSizeY: 0.6
   distToGround: 0.0
 
-  # offset of the robot footprint centre from the body-frame origin [m]
-  # use when the planning reference point is not at the geometric centre of the bounding box
-  robotCenterOffsetX: 0.0
-  robotCenterOffsetY: 0.0
   # slope / terrain constraints
   maxSlope: 0.45                # [rad]
   maxStepHeight: 0.25

--- a/gui/config/parameters.yaml
+++ b/gui/config/parameters.yaml
@@ -37,5 +37,9 @@ travConfig:
   traverseGravel: true
   traverseConcrete: true
 
-  # obstacle inflation for safety margins (scales robot radius)
+  # obstacle inflation for safety margins (scales the inflation gap beyond the
+  # AABB/OBB collision radius).  Minimum enforced value is 1.0 — setting it lower
+  # is silently clamped and a warning is logged, because the step-height check only
+  # searches within min(robotSizeX, robotSizeY)/2 and inflation must cover the rest
+  # of the footprint.  Increase above 1.0 for extra safety margins.
   obstacleInflationMultiplier: 1.0

--- a/src/TraversabilityConfig.hpp
+++ b/src/TraversabilityConfig.hpp
@@ -28,8 +28,6 @@ public:
         , robotSizeX(0.5)
         , robotSizeY(0.5)
         , distToGround(0)
-        , robotCenterOffsetX(0.0)
-        , robotCenterOffsetY(0.0)
         , slopeMetricScale(1.0)
         , slopeMetric(NONE)
         , gridResolution(0.3)
@@ -80,14 +78,6 @@ public:
      * start and goal position are expected in body frame
      */
     double distToGround;
-
-    /** Offset of the robot footprint centre from the body-frame origin, in the
-     *  robot's local XY plane.  Use when the path-planning reference point does
-     *  not coincide with the geometric centre of the robot bounding box.
-     *  The offset is applied when building the AABB/OBB collision-check box and
-     *  the RANSAC plane-fitting search area. Default: 0.0 for both axes. */
-    double robotCenterOffsetX;
-    double robotCenterOffsetY;
 
     /** Defines how strong the slope is factored into the
      *  motion cost.*/

--- a/src/TraversabilityConfig.hpp
+++ b/src/TraversabilityConfig.hpp
@@ -28,6 +28,8 @@ public:
         , robotSizeX(0.5)
         , robotSizeY(0.5)
         , distToGround(0)
+        , robotCenterOffsetX(0.0)
+        , robotCenterOffsetY(0.0)
         , slopeMetricScale(1.0)
         , slopeMetric(NONE)
         , gridResolution(0.3)
@@ -78,6 +80,14 @@ public:
      * start and goal position are expected in body frame
      */
     double distToGround;
+
+    /** Offset of the robot footprint centre from the body-frame origin, in the
+     *  robot's local XY plane.  Use when the path-planning reference point does
+     *  not coincide with the geometric centre of the robot bounding box.
+     *  The offset is applied when building the AABB/OBB collision-check box and
+     *  the RANSAC plane-fitting search area. Default: 0.0 for both axes. */
+    double robotCenterOffsetX;
+    double robotCenterOffsetY;
 
     /** Defines how strong the slope is factored into the
      *  motion cost.*/

--- a/src/TraversabilityGenerator3d.cpp
+++ b/src/TraversabilityGenerator3d.cpp
@@ -417,13 +417,14 @@ bool TraversabilityGenerator3d::checkStepHeightAABB(TravGenNode *node)
     nodePos.z() += node->getHeight();
 
     // Use the actual robot half-dimensions for the AABB search so that the
-    // detection distance is proportional to the robot footprint in each axis.
-    // Previously growSize = half-diagonal was used uniformly in X and Y, creating
-    // a square search area that overshot the footprint asymmetrically: more on the
-    // short-axis sides than the long-axis front/back, causing varying collision
-    // detection distances depending on obstacle direction.
-    Eigen::Vector3d min(-config.robotSizeX / 2.0, -config.robotSizeY / 2.0, 0);
-    Eigen::Vector3d max( config.robotSizeX / 2.0,  config.robotSizeY / 2.0, config.robotHeight);
+    // Use the smaller half-dimension as a uniform search radius on both axes.
+    // This keeps the AABB square and avoids a large dead-zone near map boundaries
+    // when robotSizeX >> robotSizeY (or vice-versa).  Cells closer than
+    // min(halfX, halfY) to any obstacle are already obstacle-free by construction;
+    // the remaining gap to the rotation-safe circle is covered by inflateObstacles.
+    const double halfSmall = std::min(config.robotSizeX, config.robotSizeY) / 2.0;
+    Eigen::Vector3d min(-halfSmall, -halfSmall, 0);
+    Eigen::Vector3d max( halfSmall,  halfSmall, config.robotHeight);
 
     min += nodePos;
     max += nodePos;
@@ -520,8 +521,9 @@ bool TraversabilityGenerator3d::checkStepHeightOBB(TravGenNode *node)
     Eigen::Quaterniond robotOrientation(rotation_matrix);
     Eigen::Vector3d robotSize{config.robotSizeX, config.robotSizeY, config.robotHeight};
 
-    Eigen::Vector3d min(-config.robotSizeX / 2.0, -config.robotSizeY / 2.0, 0);
-    Eigen::Vector3d max( config.robotSizeX / 2.0,  config.robotSizeY / 2.0, config.robotHeight);
+    const double halfSmall = std::min(config.robotSizeX, config.robotSizeY) / 2.0;
+    Eigen::Vector3d min(-halfSmall, -halfSmall, 0);
+    Eigen::Vector3d max( halfSmall,  halfSmall, config.robotHeight);
 
     min += nodePos;
     max += nodePos;
@@ -730,6 +732,7 @@ void TraversabilityGenerator3d::inflateObstacles()
 {
     const double halfRobotSizeX = config.robotSizeX / 2.0;
     const double halfRobotSizeY = config.robotSizeY / 2.0;
+
     // The AABB check already keeps the robot centre at least min(halfX, halfY) away
     // from any obstacle (the tight-axis footprint boundary).  We only need to inflate
     // by the remaining gap to half_diagonal so that the robot can still rotate freely
@@ -744,10 +747,30 @@ void TraversabilityGenerator3d::inflateObstacles()
     // gap is sub-grid and nothing gets inflated at all.
     const double inflGap = halfDiagonal - std::min(halfRobotSizeX, halfRobotSizeY);
 
+    // obstacleInflationMultiplier must be at least 1.0: the AABB/OBB collision check
+    // now uses only min(sizeX, sizeY)/2 as its search radius, so inflateObstacles
+    // must cover the remaining gap out to the larger half-dimension.  A multiplier
+    // below 1.0 would leave that gap unguarded.  Users may increase above 1.0 for
+    // extra safety margins.
+    if (config.obstacleInflationMultiplier < 1.0)
+    {
+        LOG_WARN_S << "TraversabilityGenerator3d: obstacleInflationMultiplier is "
+                   << config.obstacleInflationMultiplier
+                   << ", which is below the enforced minimum of 1.0. "
+                      "The AABB/OBB step-height check uses only min(robotSizeX, robotSizeY)/2 "
+                      "as its search radius; inflateObstacles must cover the remaining gap, "
+                      "so a multiplier < 1.0 would leave part of the robot footprint unguarded. "
+                      "Clamping to 1.0.";
+    }
+    const double effectiveMultiplier = std::max(1.0, config.obstacleInflationMultiplier);
+
     // Minimum is gridResolution*1.1, not gridResolution exactly: the distance check
     // compares cell centres, so a bare gridResolution threshold can miss neighbours
     // whose computed centre-to-centre distance is at gridResolution + floating-point noise.
-    const double inflRadius = config.obstacleInflationMultiplier *
+
+    // This is specially relevant for small robots with sizeY/2 close to gridResolution, where the gap is sub-grid and 
+    // the inflation would otherwise fail to trigger at all.
+    const double inflRadius = effectiveMultiplier *
         std::max(inflGap, config.gridResolution * 1.1) + 1e-5;
 
     for (TravGenNode *n : obstacleNodesGrowList)
@@ -765,6 +788,7 @@ void TraversabilityGenerator3d::inflateObstacles()
             // grid step apart.  Inflation radius is a horizontal clearance
             // concept, so comparing only the XY offset is correct.
             const Index diff = neighbor->getIndex() - nIdx;
+            
             const double dist2D = diff.matrix().cast<double>().norm() * config.gridResolution;
             if (dist2D < inflRadius)
             {

--- a/src/TraversabilityGenerator3d.cpp
+++ b/src/TraversabilityGenerator3d.cpp
@@ -134,11 +134,6 @@ bool TraversabilityGenerator3d::computePlaneRansac(TravGenNode& node)
         return false;
     }
 
-    // Shift to the actual footprint centre when the robot body-frame origin
-    // is not at the geometric centre of the bounding box.
-    nodePos.x() += config.robotCenterOffsetX;
-    nodePos.y() += config.robotCenterOffsetY;
-
     const double growSize = std::min(config.robotSizeX, config.robotSizeY) / 2.0;
 
     //get all surfaces in a cube of robotwidth and stepheight
@@ -421,11 +416,6 @@ bool TraversabilityGenerator3d::checkStepHeightAABB(TravGenNode *node)
     }
     nodePos.z() += node->getHeight();
 
-    // Shift to the actual footprint centre when the robot body-frame origin
-    // is not at the geometric centre of the bounding box.
-    nodePos.x() += config.robotCenterOffsetX;
-    nodePos.y() += config.robotCenterOffsetY;
-
     // Use the smaller half-dimension as a uniform search radius on both axes.
     // This keeps the AABB square and avoids a large dead-zone near map boundaries
     // when robotSizeX >> robotSizeY (or vice-versa).  Cells closer than
@@ -512,11 +502,6 @@ bool TraversabilityGenerator3d::checkStepHeightOBB(TravGenNode *node)
         return false;
     }
     nodePos.z() += node->getHeight();
-
-    // Shift to the actual footprint centre when the robot body-frame origin
-    // is not at the geometric centre of the bounding box.
-    nodePos.x() += config.robotCenterOffsetX;
-    nodePos.y() += config.robotCenterOffsetY;
 
     Eigen::Vector3d robotCenterPos = nodePos;
     robotCenterPos.z() += config.maxStepHeight + config.robotHeight/2;
@@ -756,9 +741,6 @@ void TraversabilityGenerator3d::inflateObstacles()
     const double halfDiagonal = std::sqrt(halfRobotSizeX * halfRobotSizeX + halfRobotSizeY * halfRobotSizeY);
 
     // Geometric gap between the AABB boundary and the rotation-safe circle.
-    // Clamped to at least one grid step so that the inflation always covers at
-    // least one ring of cells — otherwise, when sizeY/2 ~ gridResolution the
-    // gap is sub-grid and nothing gets inflated at all.
     const double inflGap = halfDiagonal - std::min(halfRobotSizeX, halfRobotSizeY);
 
     // obstacleInflationMultiplier must be at least 1.0: the AABB/OBB collision check

--- a/src/TraversabilityGenerator3d.cpp
+++ b/src/TraversabilityGenerator3d.cpp
@@ -728,9 +728,16 @@ void TraversabilityGenerator3d::expandAll(TravGenNode* startNode, const double e
 
 void TraversabilityGenerator3d::inflateObstacles()
 {
-    const double halfRobotSizeX = config.robotSizeX / 2;
-    const double halfRobotSizeY = config.robotSizeY / 2;
-    const double inflRadius = config.obstacleInflationMultiplier * std::sqrt((halfRobotSizeX * halfRobotSizeX) + (halfRobotSizeY * halfRobotSizeY)) + 1e-5;
+    const double halfRobotSizeX = config.robotSizeX / 2.0;
+    const double halfRobotSizeY = config.robotSizeY / 2.0;
+    // The AABB check already keeps the robot centre at least min(halfX, halfY) away
+    // from any obstacle (the tight-axis footprint boundary).  We only need to inflate
+    // by the remaining gap to half_diagonal so that the robot can still rotate freely
+    // at the edge of the traversable zone without its corners hitting the obstacle.
+    // Using the full half_diagonal here double-counts the footprint clearance and
+    // closes far too much traversable space, especially in narrow corridors.
+    const double halfDiagonal = std::sqrt(halfRobotSizeX * halfRobotSizeX + halfRobotSizeY * halfRobotSizeY);
+    const double inflRadius = config.obstacleInflationMultiplier * (halfDiagonal - std::min(halfRobotSizeX, halfRobotSizeY)) + 1e-5;
 
     for (TravGenNode *n : obstacleNodesGrowList)
     {

--- a/src/TraversabilityGenerator3d.cpp
+++ b/src/TraversabilityGenerator3d.cpp
@@ -134,6 +134,11 @@ bool TraversabilityGenerator3d::computePlaneRansac(TravGenNode& node)
         return false;
     }
 
+    // Shift to the actual footprint centre when the robot body-frame origin
+    // is not at the geometric centre of the bounding box.
+    nodePos.x() += config.robotCenterOffsetX;
+    nodePos.y() += config.robotCenterOffsetY;
+
     const double growSize = std::min(config.robotSizeX, config.robotSizeY) / 2.0;
 
     //get all surfaces in a cube of robotwidth and stepheight
@@ -416,7 +421,11 @@ bool TraversabilityGenerator3d::checkStepHeightAABB(TravGenNode *node)
     }
     nodePos.z() += node->getHeight();
 
-    // Use the actual robot half-dimensions for the AABB search so that the
+    // Shift to the actual footprint centre when the robot body-frame origin
+    // is not at the geometric centre of the bounding box.
+    nodePos.x() += config.robotCenterOffsetX;
+    nodePos.y() += config.robotCenterOffsetY;
+
     // Use the smaller half-dimension as a uniform search radius on both axes.
     // This keeps the AABB square and avoids a large dead-zone near map boundaries
     // when robotSizeX >> robotSizeY (or vice-versa).  Cells closer than
@@ -503,6 +512,11 @@ bool TraversabilityGenerator3d::checkStepHeightOBB(TravGenNode *node)
         return false;
     }
     nodePos.z() += node->getHeight();
+
+    // Shift to the actual footprint centre when the robot body-frame origin
+    // is not at the geometric centre of the bounding box.
+    nodePos.x() += config.robotCenterOffsetX;
+    nodePos.y() += config.robotCenterOffsetY;
 
     Eigen::Vector3d robotCenterPos = nodePos;
     robotCenterPos.z() += config.maxStepHeight + config.robotHeight/2;
@@ -788,7 +802,7 @@ void TraversabilityGenerator3d::inflateObstacles()
             // grid step apart.  Inflation radius is a horizontal clearance
             // concept, so comparing only the XY offset is correct.
             const Index diff = neighbor->getIndex() - nIdx;
-            
+
             const double dist2D = diff.matrix().cast<double>().norm() * config.gridResolution;
             if (dist2D < inflRadius)
             {

--- a/src/TraversabilityGenerator3d.cpp
+++ b/src/TraversabilityGenerator3d.cpp
@@ -742,8 +742,11 @@ void TraversabilityGenerator3d::inflateObstacles()
     // least one ring of cells — otherwise, when sizeY/2 ~ gridResolution the
     // gap is sub-grid and nothing gets inflated at all.
     const double inflGap = halfDiagonal - std::min(halfRobotSizeX, halfRobotSizeY);
+    // Minimum is gridResolution*1.1, not gridResolution exactly: the distance check
+    // compares cell centres, so a bare gridResolution threshold can miss neighbours
+    // whose computed centre-to-centre distance is at gridResolution + floating-point noise.
     const double inflRadius = config.obstacleInflationMultiplier *
-        std::max(inflGap, config.gridResolution) + 1e-5;
+        std::max(inflGap, config.gridResolution * 1.1) + 1e-5;
 
     for (TravGenNode *n : obstacleNodesGrowList)
     {

--- a/src/TraversabilityGenerator3d.cpp
+++ b/src/TraversabilityGenerator3d.cpp
@@ -737,11 +737,13 @@ void TraversabilityGenerator3d::inflateObstacles()
     // Using the full half_diagonal here double-counts the footprint clearance and
     // closes far too much traversable space, especially in narrow corridors.
     const double halfDiagonal = std::sqrt(halfRobotSizeX * halfRobotSizeX + halfRobotSizeY * halfRobotSizeY);
+
     // Geometric gap between the AABB boundary and the rotation-safe circle.
     // Clamped to at least one grid step so that the inflation always covers at
     // least one ring of cells — otherwise, when sizeY/2 ~ gridResolution the
     // gap is sub-grid and nothing gets inflated at all.
     const double inflGap = halfDiagonal - std::min(halfRobotSizeX, halfRobotSizeY);
+
     // Minimum is gridResolution*1.1, not gridResolution exactly: the distance check
     // compares cell centres, so a bare gridResolution threshold can miss neighbours
     // whose computed centre-to-centre distance is at gridResolution + floating-point noise.
@@ -750,10 +752,21 @@ void TraversabilityGenerator3d::inflateObstacles()
 
     for (TravGenNode *n : obstacleNodesGrowList)
     {
+        const Index nIdx = n->getIndex();
         n->eachConnectedNode([&] (maps::grid::TraversabilityNodeBase *neighbor, bool &expandNode, bool &stop)
         {
             TravGenNode* node = static_cast<TravGenNode*>(neighbor);
-            if ((n->getPosition(trMap) - neighbor->getPosition(trMap)).norm() < inflRadius)
+
+            // Use 2D (XY) grid-cell distance for the inflation check.
+            // RANSAC can produce obstacle nodes with slightly wrong heights
+            // (e.g. below the floor plane when wall patches pull the fitted
+            // plane downward), which makes the 3D distance to an adjacent
+            // traversable cell exceed inflRadius even when they are only one
+            // grid step apart.  Inflation radius is a horizontal clearance
+            // concept, so comparing only the XY offset is correct.
+            const Index diff = neighbor->getIndex() - nIdx;
+            const double dist2D = diff.matrix().cast<double>().norm() * config.gridResolution;
+            if (dist2D < inflRadius)
             {
                 if(node->getUserData().nodeType == NodeType::TRAVERSABLE ||
                    node->getUserData().nodeType == NodeType::INFLATED_FRONTIER ||

--- a/src/TraversabilityGenerator3d.cpp
+++ b/src/TraversabilityGenerator3d.cpp
@@ -737,7 +737,13 @@ void TraversabilityGenerator3d::inflateObstacles()
     // Using the full half_diagonal here double-counts the footprint clearance and
     // closes far too much traversable space, especially in narrow corridors.
     const double halfDiagonal = std::sqrt(halfRobotSizeX * halfRobotSizeX + halfRobotSizeY * halfRobotSizeY);
-    const double inflRadius = config.obstacleInflationMultiplier * (halfDiagonal - std::min(halfRobotSizeX, halfRobotSizeY)) + 1e-5;
+    // Geometric gap between the AABB boundary and the rotation-safe circle.
+    // Clamped to at least one grid step so that the inflation always covers at
+    // least one ring of cells — otherwise, when sizeY/2 ~ gridResolution the
+    // gap is sub-grid and nothing gets inflated at all.
+    const double inflGap = halfDiagonal - std::min(halfRobotSizeX, halfRobotSizeY);
+    const double inflRadius = config.obstacleInflationMultiplier *
+        std::max(inflGap, config.gridResolution) + 1e-5;
 
     for (TravGenNode *n : obstacleNodesGrowList)
     {


### PR DESCRIPTION
Update inflation logic: we use the smaller dimension of the robot for collision checking then inflate the remaining gap from robot radius with inflation to cover all yaw configurations of robot body.

Add robot bounding box to the GUI

Inflation looks at 2D distance from connected neighbour because 3D distance might at times fail due to ransac 
plane fitting finding patches below surface in regions close to walls etc.